### PR TITLE
[SPARK-17642] support DESC FORMATTED TABLE COLUMN command to show column-level statistics

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -305,7 +305,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
       val columns = descColNameContext.identifier().asScala.map(_.getText)
       DescribeColumnsCommand(
         visitTableIdentifier(ctx.tableIdentifier),
-        columns.head,
+        columns,
         ctx.EXTENDED != null,
         ctx.FORMATTED != null)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -303,7 +303,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
     val descColNameContext = ctx.describeColName
     if (descColNameContext != null) {
       val column = descColNameContext.identifier().asScala.map(_.getText)
-      DescribeColumnsCommand(
+      DescribeColumnCommand(
         visitTableIdentifier(ctx.tableIdentifier),
         column,
         ctx.EXTENDED != null,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -302,10 +302,10 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
   override def visitDescribeTable(ctx: DescribeTableContext): LogicalPlan = withOrigin(ctx) {
     val descColNameContext = ctx.describeColName
     if (descColNameContext != null) {
-      val columns = descColNameContext.identifier().asScala.map(_.getText)
+      val column = descColNameContext.identifier().asScala.map(_.getText)
       DescribeColumnsCommand(
         visitTableIdentifier(ctx.tableIdentifier),
-        columns,
+        column,
         ctx.EXTENDED != null,
         ctx.FORMATTED != null)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -300,10 +300,14 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder {
    * Create a [[DescribeTableCommand]] logical plan.
    */
   override def visitDescribeTable(ctx: DescribeTableContext): LogicalPlan = withOrigin(ctx) {
-    // Describe column are not supported yet. Return null and let the parser decide
-    // what to do with this (create an exception or pass it on to a different system).
-    if (ctx.describeColName != null) {
-      null
+    val descColNameContext = ctx.describeColName
+    if (descColNameContext != null) {
+      val columns = descColNameContext.identifier().asScala.map(_.getText)
+      DescribeColumnsCommand(
+        visitTableIdentifier(ctx.tableIdentifier),
+        columns.head,
+        ctx.EXTENDED != null,
+        ctx.FORMATTED != null)
     } else {
       val partitionSpec = if (ctx.partitionSpec != null) {
         // According to the syntax, visitPartitionSpec returns `Map[String, Option[String]]`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -637,14 +637,12 @@ case class DescribeColumnCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val result = new ArrayBuffer[Row]
     val catalog = sparkSession.sessionState.catalog
-    val project = Project(Seq(UnresolvedAttribute(column)), catalog.lookupRelation(table))
     val queryExecution = sparkSession.sessionState.executePlan(
       Project(Seq(UnresolvedAttribute(column)), catalog.lookupRelation(table)))
     val analyzed = queryExecution.analyzed
     queryExecution.assertAnalyzed()
 
     val isTemporary = catalog.isTemporaryTable(table)
-    val fields = analyzed.schema.fields
     val colStats = if (isTemporary) {
       AttributeMap(Nil)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -27,6 +27,7 @@ import scala.util.control.NonFatal
 import scala.util.Try
 
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchPartitionException, UnresolvedAttribute}
@@ -592,7 +593,7 @@ case class DescribeTableCommand(
  *   DESCRIBE [EXTENDED|FORMATTED] table_name column_name;
  * }}}
  */
-case class DescribeColumnsCommand(
+case class DescribeColumnCommand(
     table: TableIdentifier,
     column: Seq[String],
     isExtended: Boolean,

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -212,18 +212,18 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
   test("describe table column") {
     val df = (1 to 99).map(x => (x, s"$x")).toDF("key", "value")
     // test for the temp table
-    df.createOrReplaceTempView("table1")
-    checkAnswer(sql("desc table1 key"), Row("key", "int", null))
-    checkAnswer(sql("desc extended table1 key"), Row("key", "int", null))
-    checkAnswer(sql("desc formatted table1 key"),
+    df.createOrReplaceTempView("tempTable")
+    checkAnswer(sql("desc tempTable key"), Row("key", "int", null))
+    checkAnswer(sql("desc extended tempTable key"), Row("key", "int", null))
+    checkAnswer(sql("desc formatted tempTable key"),
       Row("key", "int", null, null, null, null, null, null, null))
 
-    withTable("table2") {
+    withTable("persistTable") {
       // test for the persist table
-      df.write.saveAsTable("table2")
-      checkAnswer(sql("desc table2 key"), Row("key", "int", null))
-      checkAnswer(sql("desc extended table2 key"), Row("key", "int", null))
-      checkAnswer(sql("desc formatted table2 key"),
+      df.write.saveAsTable("persistTable")
+      checkAnswer(sql("desc persistTable key"), Row("key", "int", null))
+      checkAnswer(sql("desc extended persistTable key"), Row("key", "int", null))
+      checkAnswer(sql("desc formatted persistTable key"),
         Row("key", "int", null, null, null, null, null, null, null))
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -208,6 +208,33 @@ class SQLQuerySuite extends QueryTest with SharedSQLContext {
     assert(d1.map(_(1)) === d2.map(_(1)))
   }
 
+
+  test("describe table column") {
+    val df = (1 to 99).map(x => (x, s"$x")).toDF("key", "value")
+    // test for the temp table
+    df.createOrReplaceTempView("table1")
+    checkAnswer(sql("desc table1 key"), Row("key", "int", null))
+    checkAnswer(sql("desc extended table1 key"), Row("key", "int", null))
+    checkAnswer(sql("desc formatted table1 key"),
+      Row("key", "int", null, null, null, null, null, null, null))
+
+    withTable("table2") {
+      // test for the persist table
+      df.write.saveAsTable("table2")
+      checkAnswer(sql("desc table2 key"), Row("key", "int", null))
+      checkAnswer(sql("desc extended table2 key"), Row("key", "int", null))
+      checkAnswer(sql("desc formatted table2 key"),
+        Row("key", "int", null, null, null, null, null, null, null))
+    }
+
+    withTable("complexTable") {
+      complexData.write.saveAsTable("complexTable")
+      checkAnswer(sql("desc complexTable s.key"), Row("key", "int", null))
+      checkAnswer(sql("desc formatted complexTable s.key"),
+        Row("key", "int", null, null, null, null, null, null, null))
+    }
+  }
+
   test("grouping on nested fields") {
     spark.read.json(sparkContext.parallelize(
       """{"nested": {"attribute": 1}, "value": 2}""" :: Nil))

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -155,6 +155,7 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
       sql(s"ANALYZE TABLE stats_table COMPUTE STATISTICS FOR COLUMNS ${columns.mkString(",")}")
       stats.zip(df.schema).foreach { case(sta, sch) =>
         val columnStat = sta._2
+        sql(s"desc formatted stats_table ${sch.name}").show()
         checkAnswer(sql(s"desc formatted stats_table ${sch.name}"),
           Row(sta._1, sch.dataType.simpleString,
             columnStat.min.map(_.toString).orNull,

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -165,9 +165,6 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
             columnStat.maxLen.toString,
             sch.getComment().orNull))
       }
-      columns.foreach { cl =>
-        sql(s"desc formatted stats_table $cl").show()
-      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -155,7 +155,6 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
       sql(s"ANALYZE TABLE stats_table COMPUTE STATISTICS FOR COLUMNS ${columns.mkString(",")}")
       stats.zip(df.schema).foreach { case(sta, sch) =>
         val columnStat = sta._2
-        sql(s"desc formatted stats_table ${sch.name}").show()
         checkAnswer(sql(s"desc formatted stats_table ${sch.name}"),
           Row(sta._1, sch.dataType.simpleString,
             columnStat.min.map(_.toString).orNull,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -120,25 +120,6 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     }
   }
 
-  test("describe table column") {
-    val df = (1 to 99).map(x => (x, s"$x")).toDF("key", "value")
-    // test for the temp table
-    df.createOrReplaceTempView("table1")
-    checkAnswer(sql("desc table1 key"), Row("key", "int", null))
-    checkAnswer(sql("desc extended table1 key"), Row("key", "int", null))
-    checkAnswer(sql("desc formatted table1 key"),
-      Row("key", "int", null, null, null, null, null, null, null))
-
-    withTable("table2") {
-      // test for the persist table
-      df.write.saveAsTable("table2")
-      checkAnswer(sql("desc table2 key"), Row("key", "int", null))
-      checkAnswer(sql("desc extended table2 key"), Row("key", "int", null))
-      checkAnswer(sql("desc formatted table2 key"),
-        Row("key", "int", null, null, null, null, null, null, null))
-    }
-  }
-
   test("permanent UDTF") {
     withUserDefinedFunction("udtf_count_temp" -> false) {
       sql(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -120,19 +120,19 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     }
   }
 
-  test("describe table columns") {
-    sql("create table wftest(key int, value string, m1 bigint, m2 decimal(8, 3))")
-    sql("desc wftest").show()
-    sql("desc formatted wftest").show()
-    sql("desc wftest key").show()
-    sql("desc wftest value").show()
-    sql("desc wftest m1").show()
-    sql("desc wftest m2").show()
+  test("describe table column") {
+    // test temp table column
+    sql("create temp table temp_table_desc_column(d1 string, d2 int) using parquet")
+    sql("desc temp_table_desc_column d1").show()
+    sql("desc extended temp_table_desc_column d1").show()
+    sql("desc formatted temp_table_desc_column d1").show()
 
-    sql("desc formatted wftest key").show()
-    sql("desc formatted wftest value").show()
-    sql("desc formatted wftest m1").show()
-    sql("desc formatted wftest m2").show()
+
+    // test persist table column
+    sql("create table table_desc_column(d1 string, d2 int) using parquet")
+    sql("desc table_desc_column d1").show()
+    sql("desc extended table_desc_column d1").show()
+    sql("desc formatted table_desc_column d1").show()
 
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -120,6 +120,17 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     }
   }
 
+  test("describe table columns") {
+    sql("create table wftest(key int, value string, m1 bigint, m2 decimal(8, 3))")
+    sql("desc wftest").show()
+    sql("desc formatted wftest").show()
+    sql("desc wftest key").show()
+    sql("desc wftest value").show()
+    sql("desc wftest m1").show()
+    sql("desc wftest m2").show()
+
+  }
+
   test("permanent UDTF") {
     withUserDefinedFunction("udtf_count_temp" -> false) {
       sql(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -129,6 +129,11 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
     sql("desc wftest m1").show()
     sql("desc wftest m2").show()
 
+    sql("desc formatted wftest key").show()
+    sql("desc formatted wftest value").show()
+    sql("desc formatted wftest m1").show()
+    sql("desc formatted wftest m2").show()
+
   }
 
   test("permanent UDTF") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -121,19 +121,22 @@ class SQLQuerySuite extends QueryTest with SQLTestUtils with TestHiveSingleton {
   }
 
   test("describe table column") {
-    // test temp table column
-    sql("create temp table temp_table_desc_column(d1 string, d2 int) using parquet")
-    sql("desc temp_table_desc_column d1").show()
-    sql("desc extended temp_table_desc_column d1").show()
-    sql("desc formatted temp_table_desc_column d1").show()
+    val df = (1 to 99).map(x => (x, s"$x")).toDF("key", "value")
+    // test for the temp table
+    df.createOrReplaceTempView("table1")
+    checkAnswer(sql("desc table1 key"), Row("key", "int", null))
+    checkAnswer(sql("desc extended table1 key"), Row("key", "int", null))
+    checkAnswer(sql("desc formatted table1 key"),
+      Row("key", "int", null, null, null, null, null, null, null))
 
-
-    // test persist table column
-    sql("create table table_desc_column(d1 string, d2 int) using parquet")
-    sql("desc table_desc_column d1").show()
-    sql("desc extended table_desc_column d1").show()
-    sql("desc formatted table_desc_column d1").show()
-
+    withTable("table2") {
+      // test for the persist table
+      df.write.saveAsTable("table2")
+      checkAnswer(sql("desc table2 key"), Row("key", "int", null))
+      checkAnswer(sql("desc extended table2 key"), Row("key", "int", null))
+      checkAnswer(sql("desc formatted table2 key"),
+        Row("key", "int", null, null, null, null, null, null, null))
+    }
   }
 
   test("permanent UDTF") {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support DESC FORMATTED TABLE COLUMN command to show column-level statistics.

```
sql: desc formatted stats_table cbool
output: 
+--------+---------+-----+----+---------+--------------+-----------+-----------+-------+
|col_name|data_type|  min| max|num_nulls|distinct_count|avg_col_len|max_col_len|comment|
+--------+---------+-----+----+---------+--------------+-----------+-----------+-------+
|   cbool|  boolean|false|true|        1|             2|          1|          1|   null|
+--------+---------+-----+----+---------+--------------+-----------+-----------+-------+

sql: desc stats_table cbool  or desc extended stats_table cbool 
output: 
+--------+---------+-------+
|col_name|data_type|comment|
+--------+---------+-------+
|   cbool|  boolean|   null|
+--------+---------+-------+
```

## How was this patch tested?

Added tests